### PR TITLE
Source formatting

### DIFF
--- a/sandbox/taglibs/alloy-taglib/src/com/liferay/alloy/tools/tagbuilder/templates/init_jsp.ftl
+++ b/sandbox/taglibs/alloy-taglib/src/com/liferay/alloy/tools/tagbuilder/templates/init_jsp.ftl
@@ -83,7 +83,7 @@ _updateOptions(_options, "${attribute.getSafeName()}", ${attribute.getSafeName()
 </#list>
 %>
 
-<%@ include file="init-ext.jspf" %>
+<%@ include file="${jspRelativePath}init-ext.jspf" %>
 
 <%!
 private static final String _NAMESPACE = "${namespace}";


### PR DESCRIPTION
Hey Eduardo,

I would like to have the entire path name for the include init-ext in the generated init files.
At the moment it's just: <%@ include file="init-ext.jspf" %> 

It's necessary for some work I am doing on the SourceFormatter. Basically we are making it required to have the entire path whenever you include (instead of just the file name),

I am not sure if my change even is correct syntax, but you'll figure it out :-)

Thanks,
