### PR TITLE
Have domType default to button when no value is specified

### DIFF
--- a/src/aui-toolbar/js/aui-toolbar.js
+++ b/src/aui-toolbar/js/aui-toolbar.js
@@ -359,6 +359,7 @@ ToolbarRenderer.prototype = {
         button: function(childRenderHints) {
             var instance = this,
                 value = childRenderHints.value,
+                type = value.domType || BUTTON,
                 cssClass,
                 buttonNode;
 
@@ -373,14 +374,14 @@ ToolbarRenderer.prototype = {
                 // silently fails when that happens.
                 try {
                     // Add type support
-                    buttonNode.setAttribute('type', value.domType || BUTTON);
+                    buttonNode.setAttribute('type', type);
                 }
                 catch(err) {}
             }
             else {
                 buttonNode = A.Node.create(
                     A.ButtonExt.getTypedButtonTemplate(
-                        instance.TEMPLATES.button, value.domType));
+                        instance.TEMPLATES.button, type));
             }
 
             // Add cssClass support


### PR DESCRIPTION
Hey @eduardolundgren,

After testing it out in Portal, I noticed that it does not default to button type when it's generating the button via the getTypedButtonTemplate. Therefore when creating a toolbar you'd have to specify the type for every child. This fix configures it to default to button type whether it's being generated by the template, or being passed in from the dom.
