### PR TITLE
Fix A.TabView's extend attribute

### DIFF
--- a/src/aui-tabview/js/aui-tabview.js
+++ b/src/aui-tabview/js/aui-tabview.js
@@ -194,6 +194,7 @@ A.TabView.CSS_PREFIX = getClassName(TABBABLE);
  * Check the [live demo](http://alloyui.com/examples/tabview/).
  *
  * @class A.TabView
+ * @extends TabView
  * @param config {Object} Object literal specifying widget configuration properties.
  * @constructor
  */


### PR DESCRIPTION
It wasn't an issue related to the API Docs generation itself, it was only a missing attribute.
