### PR TITLE
AUI-1194 select option with empty option-text or value can not be create...

### DIFF
--- a/src/aui-datatable/js/aui-datatable-edit.js
+++ b/src/aui-datatable/js/aui-datatable-edit.js
@@ -1282,7 +1282,7 @@ var BaseOptionsCellEditor = A.Component.create({
                     var name = inputName.val();
                     var value = values.item(index).val();
 
-                    if (name && value) {
+                    if (name || value) {
                         options[value] = name;
                     }
                 });


### PR DESCRIPTION
...d with aui-datatable-edit

Hey Eduardo,

Our opinion is that datatable-edit select should be able to contain such options which value or text can be empty similar the basic html select.
