### PR TITLE
[TECHNICAL-SUPPORT] AUI-1201 IE - No minimum required flash version set for the video flash player.

### DIFF
--- a/src/aui-video/js/aui-video.js
+++ b/src/aui-video/js/aui-video.js
@@ -12,6 +12,7 @@ var Lang = A.Lang,
     CSS_VIDEO_NODE = getClassName('video', 'node'),
 
     DEFAULT_PLAYER_PATH = A.config.base + 'aui-video/assets/player.swf?t=' + Lang.now(),
+    PLAYER_FLASH_VERSION = '9,0,0,0',
 
     DOC = A.config.doc,
 
@@ -116,6 +117,17 @@ var Video = A.Component.create({
          */
         flashVars: {
             value: {}
+        },
+
+        /**
+         * The required Flash version for the swf player
+         *
+         * @attribute playerFlashVersion
+         * @default '9,0,0,0'
+         * @type String
+         */
+        playerFlashVersion: {
+            value: PLAYER_FLASH_VERSION
         },
 
         /**
@@ -277,7 +289,9 @@ var Video = A.Component.create({
                 var tplObj = '<object id="' + instance._swfId + '" ';
 
                 if (UA.ie) {
-                    tplObj += 'classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" ';
+                    tplObj += 'classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" ' +
+                        'codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=' +
+                        instance.get('playerFlashVersion') + '" ';
                 }
                 else {
                     tplObj += 'type="application/x-shockwave-flash" data="' + swfUrl + '" ';


### PR DESCRIPTION
Hey Eduardo,

The main problem was the Flash version which could cause the exception and definitely that was the reason why the videos didn't appear. To fix the problem the only solution is to update the Flash. We can declare the minimum required Flash version (9.0.0 for the 3rd party FlashFox) so that the browser can notify the user that he/she needs to install/update it.
It is tested in VM XP + IE8 (and please do not test with IE9/10/11 with emulation).

On the ticket you can find further info.

Thanks,
 Zsaga
