### PR TITLE
AUI-1278 - A.Plugin.AutosizeIframe.getContentHeight returns wrong content heights

### DIFF
--- a/src/aui-autosize/js/aui-autosize-iframe.js
+++ b/src/aui-autosize/js/aui-autosize-iframe.js
@@ -407,10 +407,6 @@ A.mix(AutosizeIframe, {
         if (iframeDoc && iframeWin.location.href != 'about:blank') {
             var docEl = iframeDoc.documentElement;
 
-            if (docEl) {
-                docEl.style.overflowY = 'hidden';
-            }
-
             var docOffsetHeight = (docEl && docEl.offsetHeight) || 0;
 
             var standardsMode = (iframeDoc.compatMode == 'CSS1Compat');


### PR DESCRIPTION
Hey @eduardolundgren,

Attached is an update for http://issues.liferay.com/browse/AUI-1278.

Please let me know if you have any questions.  Thanks!
