### PR TITLE
AUI-1279 Remove ancestors implementation and update ancestorsByClassName

### DIFF
--- a/src/aui-node/js/aui-node-base.js
+++ b/src/aui-node/js/aui-node-base.js
@@ -130,14 +130,20 @@ A.mix(NODE_PROTO, {
      * @method ancestorsByClassName
      * @param {String} className A selector to filter the ancestor elements
      *     against.
+     * @param {Boolean} testSelf optional Whether or not to include the element
+     * in the scan
      * @return {NodeList}
      */
-    ancestorsByClassName: function(className) {
+    ancestorsByClassName: function(className, testSelf) {
         var instance = this;
 
         var ancestors = [];
         var cssRE = new RegExp('\\b' + className + '\\b');
         var currentEl = instance.getDOM();
+
+        if (!testSelf) {
+            currentEl = currentEl.parentNode;
+        }
 
         while (currentEl && currentEl.nodeType !== 9) {
             if (currentEl.nodeType === 1 && cssRE.test(currentEl.className)) {


### PR DESCRIPTION
- Removes custom `ancestors` implementation, which was clashing with YUI's method.
- Updates `ancestorsByClassname` with `testSelf` option to match ancestors default behaviour

cc @ipeychev, @natecavanaugh
