### PR TITLE
AUI-1376 Fix syntax error on IE8

### DIFF
--- a/src/aui-scheduler/js/aui-scheduler-event-recorder.js
+++ b/src/aui-scheduler/js/aui-scheduler-event-recorder.js
@@ -546,7 +546,7 @@ var SchedulerEventRecorder = A.Component.create({
 
             if (event) {
                 children.push({
-                    label: strings.delete,
+                    label: strings['delete'],
                     on: {
                         click: A.bind(instance._handleDeleteEvent, instance)
                     }


### PR DESCRIPTION
Hey @eduardolundgren,

This usage of `.delete` it's not supported on IE8, and throws exceptions in the `aui-scheduler` tests.

This was recently changed to conform to jshint, but running `gulp lint` doesn't seem to complain.

Thanks!

/cc @ipeychev
