### PR TITLE
AUI-1419 Safari only - SPA will continuously reload the page if an iframe with src attribute exists on the page 

### DIFF
--- a/src/aui-surface/js/aui-surface-app.js
+++ b/src/aui-surface/js/aui-surface-app.js
@@ -115,6 +115,8 @@ A.SurfaceApp = A.Base.create('surface-app', A.Base, [], {
      * @protected
      */
     initializer: function() {
+        var instance = this;
+
         this.routes = [];
         this.surfaces = {};
         this.screens = {};
@@ -128,7 +130,11 @@ A.SurfaceApp = A.Base.create('surface-app', A.Base, [], {
             endNavigate: {}
         });
         A.on('scroll', A.debounce(this._onScroll, 50, this));
-        A.on('popstate', this._onPopState, win, this);
+
+        this.on('domready', function() {
+            A.on('popstate', instance._onPopState, win, instance);
+        });
+
         A.delegate('click', this._onDocClick, doc, this.get('linkSelector'), this);
     },
 


### PR DESCRIPTION
Hey Eduardo. This issue is related to a portal bug: https://issues.liferay.com/browse/LPS-47486. Any page that has an iframe with src will be affected by this, so I found that defering the popstate listener to domready was the right fix. I put a gif showing the bug on the AUI ticket if you are too lazy to test all the steps. Go Brazil
