### PR TITLE
AUI-1356 Use 'for' as the preferred way to find field label

### DIFF
--- a/src/aui-form-validator/js/aui-form-validator.js
+++ b/src/aui-form-validator/js/aui-form-validator.js
@@ -1119,7 +1119,9 @@ var FormValidator = A.Component.create({
          */
         _findFieldLabel: function(field) {
             var labelCssClass = '.' + this.get('labelCssClass'),
-                label = field.previous(labelCssClass) || field.ancestor().previous(labelCssClass);
+                label =  A.one('label[for=' + field.get('id') + ']');
+
+            label = label ? label : field.ancestor().previous(labelCssClass);
 
             if (label) {
                 return label.get('text');

--- a/src/aui-form-validator/tests/unit/index.html
+++ b/src/aui-form-validator/tests/unit/index.html
@@ -72,7 +72,7 @@
       </div>
 
       <div class="form-group">
-        <label class="control-label" ><input type="checkbox" name="read" id="read" value="true" />I have read and understood this form</label>
+        <label class="control-label" for="read"><input type="checkbox" name="read" id="read" value="true" />I have read and understood this form</label>
 
       </div>
 


### PR DESCRIPTION
Hi @eduardolundgren,

Here is an update for https://issues.liferay.com/browse/AUI-1356.

The 'field.ancestor(labelClass)' is needed for input field that has the label as it's direct ancestor. For example, the checkbox input at the end of the form in the form validator unit test. However, I agree with you that field.ancestor(labelClass) is too loose. I think using 'for' is still probably the best way to get an input field's label, so I made the change to make 'for' as the preferred way to get the label and kept 'field.ancestor().previous(labelCssClass)' for radio button inputs. Please let me know if there's any issues. Thanks!
