### PR TITLE
AUI-1544 Fixing padding nodes error in month view

### DIFF
--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -1088,6 +1088,10 @@ var SchedulerTableView = A.Component.create({
                 evt.addPaddingNode();
             }
 
+            if (evtNodeList.size() <= paddingNodeIndex) {
+                paddingNodeIndex = evtNodeList.size() - 1;
+            }
+
             var evtNode = evtNodeList.item(paddingNodeIndex);
 
             evtNode.setStyles({


### PR DESCRIPTION
Hi Eduardo! :blush:

With the sample code I provided in the issue description, a NPE appears in the `_syncEventNodeUI` method. I think it happens when an event is "hidden" for 2 weeks because those cells overflow, then, when there's room for it in the cells of the third weeks, it can finally appear.
