### PR TITLE
AUI-1546 Fixing the 'Show x more' link logic in month view

### DIFF
--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -396,7 +396,19 @@ var SchedulerTableView = A.Component.create({
             var rowNode = A.Node.create(TPL_SVT_TABLE_DATA_ROW);
 
             instance.loopDates(rowStartDate, rowEndDate, function(celDate, index) {
+                var key = String(celDate.getTime());
+
+                var evtRenderedStack = instance.evtRenderedStack[key];
+
+                if (!evtRenderedStack) {
+                    instance.evtRenderedStack[key] = [];
+
+                    evtRenderedStack = instance.evtRenderedStack[key];
+                }
+
                 if (rowRenderedColumns > index) {
+                    evtRenderedStack.push(null);
+
                     return;
                 }
 
@@ -406,13 +418,13 @@ var SchedulerTableView = A.Component.create({
                 var evtColNode = A.Node.create(TPL_SVT_TABLE_DATA_COL);
                 var evtNodeContainer = evtColNode.one('div');
 
-                if ((displayRows < events.length) && (rowDisplayIndex === (displayRows - 1))) {
+                if ((evtRenderedStack.length < events.length) && (rowDisplayIndex === (displayRows - 1))) {
                     var strings = instance.get('strings');
 
                     var showMoreEventsLink = A.Node.create(
                         Lang.sub(
                             TPL_SVT_MORE, {
-                                count: (events.length - (displayRows - 1)),
+                                count: (events.length - evtRenderedStack.length),
                                 labelPrefix: strings.show,
                                 labelSuffix: strings.more
                             }
@@ -433,9 +445,7 @@ var SchedulerTableView = A.Component.create({
                     instance._syncEventNodeContainerUI(evt, evtNodeContainer, evtSplitInfo);
                     instance._syncEventNodeUI(evt, evtNodeContainer, celDate);
 
-                    var key = String(celDate.getTime());
-
-                    instance.evtRenderedStack[key].push(evt);
+                    evtRenderedStack.push(evt);
                 }
 
                 rowRenderedColumns++;


### PR DESCRIPTION
As far as I understood the `_getRenderableEvent` method, an event which starts the first day of a week isn't rendered in that week if the first day is already full. I had a look at Google Calendar, and they seem to do the same.

With this change, an `evtRenderedStack` entry contains all the events that are rendered from that specific day, plus a number of null values for the events the span in that day (we don't need to store the actual events, just the number of them). Then, we show the "Show x more" link if we're rendering the last available row and the number of events we rendered in that day is less than the number of events we should show.
