### PR TITLE
AUI-1771 Display all events in scheduler's month view

### DIFF
--- a/demos/scheduler/perf.html
+++ b/demos/scheduler/perf.html
@@ -44,7 +44,10 @@
 
         var time = Date.now();
 
-        var monthView = new Y.SchedulerMonthView();
+        var monthView = new Y.SchedulerMonthView({
+            displayRows: Infinity,
+            height: 'auto'
+        });
         var scheduler = new Y.Scheduler({
             activeView: monthView,
             boundingBox: '#scheduler',

--- a/src/aui-scheduler/HISTORY.md
+++ b/src/aui-scheduler/HISTORY.md
@@ -5,6 +5,7 @@
 ## @VERSION@
 
 * [AUI-1640](https://issues.liferay.com/browse/AUI-1640) Scheduler should create SchedulerEvent instances lazily
+* [AUI-1771](https://issues.liferay.com/browse/AUI-1771) Display all events in scheduler's month view
 * [AUI-1772](https://issues.liferay.com/browse/AUI-1772) Improve performance of SchedulerTableView plotEvents method
 
 ## [3.0.0](https://github.com/liferay/alloy-ui/releases/tag/3.0.0)

--- a/src/aui-scheduler/assets/aui-scheduler-view-month-core.css
+++ b/src/aui-scheduler/assets/aui-scheduler-view-month-core.css
@@ -2,6 +2,11 @@
     display: none;
 }
 
+.scheduler-view-month .scheduler-view-table-row {
+    height: 16.666%;
+    min-height: 100px;
+}
+
 .scheduler-view-month .scheduler-view-table-colgrid-first {
     border-left: 0 none;
 }

--- a/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
+++ b/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
@@ -89,23 +89,30 @@
 
 .scheduler-view-table-row-container {
     background: #fff;
-    bottom: 0;
-    left: 0;
+    height: 100%;
     overflow: hidden;
-    position: absolute;
-    top: 0;
     width: 100%;
 }
 
 .scheduler-view-table-row {
     left: 0;
+    min-height: 100%;
     overflow: hidden;
-    position: absolute;
+    position: relative;
     width: 100%;
 }
 
-.scheduler-view-table-grid-first {
+.scheduler-view-table-grid-first .scheduler-view-table-grid {
     border-top: 0;
+}
+
+.scheduler-view-table-grid-container {
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    right: 0;
+    table-layout: fixed;
+    top: 0;
 }
 
 .scheduler-view-table-grid {

--- a/src/aui-scheduler/js/aui-scheduler-base-view.js
+++ b/src/aui-scheduler/js/aui-scheduler-base-view.js
@@ -87,7 +87,7 @@ var SchedulerView = A.Component.create({
          * @type {Number}
          */
         height: {
-            value: 600
+            value: 650
         },
 
         /**

--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -50,6 +50,7 @@ var Lang = A.Lang,
     CSS_SVT_TABLE_DATA_EVENT_RIGHT = getCN('scheduler-view', 'table', 'data', 'event', 'right'),
     CSS_SVT_TABLE_DATA_FIRST = getCN('scheduler-view', 'table', 'data', 'first'),
     CSS_SVT_TABLE_GRID = getCN('scheduler-view', 'table', 'grid'),
+    CSS_SVT_TABLE_GRID_CONTAINER = getCN('scheduler-view', 'table', 'grid', 'container'),
     CSS_SVT_TABLE_GRID_FIRST = getCN('scheduler-view', 'table', 'grid', 'first'),
 
     TPL_SVT_CONTAINER = '<div class="' + CSS_SVT_CONTAINER + '">' +
@@ -73,17 +74,18 @@ var Lang = A.Lang,
 
     TPL_SVT_MORE = '<a href="javascript:;" class="' + CSS_SVT_MORE + '">{labelPrefix} {count} {labelSuffix}</a>',
 
-    TPL_SVT_ROW = '<div class="' + CSS_SVT_ROW + '" style="top: {top}%; height: {height}%;"></div>',
+    TPL_SVT_ROW = '<div class="' + CSS_SVT_ROW + '"></div>',
 
     TPL_SVT_TABLE_DATA = '<table cellspacing="0" cellpadding="0" class="' + CSS_SVT_TABLE_DATA + '">' +
         '<tbody></tbody>' +
         '</table>',
 
-    TPL_SVT_TABLE_GRID = '<table cellspacing="0" cellpadding="0" class="' + CSS_SVT_TABLE_GRID + '">' +
+    TPL_SVT_TABLE_GRID = '<div class="' + CSS_SVT_TABLE_GRID_CONTAINER + '">' +
+        '<table cellspacing="0" cellpadding="0" class="' + CSS_SVT_TABLE_GRID + '">' +
         '<tbody>' +
         '<tr></tr>' +
         '</tbody>' +
-        '</table>',
+        '</table></div>',
 
     TPL_SVT_EV_ICON_LEFT = '<span class="' + [CSS_ICON, CSS_ICON_ARROWSTOP_LEFT].join(' ') + '"></span>',
     TPL_SVT_EV_ICON_RIGHT = '<span class="' + [CSS_ICON, CSS_ICON_ARROWSTOP_RIGHT].join(' ') + '"></span>',
@@ -394,6 +396,8 @@ var SchedulerTableView = A.Component.create({
             var rowRenderedColumns = 0;
             var rowNode = A.Node.create(TPL_SVT_TABLE_DATA_ROW);
 
+            var renderedEvents = false;
+
             instance.loopDates(rowStartDate, rowEndDate, function(celDate, index) {
                 var key = String(celDate.getTime());
 
@@ -417,7 +421,7 @@ var SchedulerTableView = A.Component.create({
                 var evtColNode = A.Node.create(TPL_SVT_TABLE_DATA_COL);
                 var evtNodeContainer = evtColNode.one('div');
 
-                if ((evtRenderedStack.length < events.length) && (rowDisplayIndex === (displayRows - 1))) {
+                if ((evtRenderedStack.length < events.length) && displayRows && (rowDisplayIndex === (displayRows - 1))) {
                     var strings = instance.get('strings');
 
                     var showMoreEventsLink = A.Node.create(
@@ -433,6 +437,7 @@ var SchedulerTableView = A.Component.create({
                     showMoreEventsLink.setData('events', events);
 
                     evtNodeContainer.append(showMoreEventsLink);
+                    renderedEvents = true;
                 }
                 else if (evt) {
                     var evtSplitInfo = instance._getEvtSplitInfo(evt, celDate, rowStartDate, rowEndDate);
@@ -445,6 +450,7 @@ var SchedulerTableView = A.Component.create({
                     instance._syncEventNodeUI(evt, evtNodeContainer, celDate);
 
                     evtRenderedStack.push(evt);
+                    renderedEvents = true;
                 }
 
                 rowRenderedColumns++;
@@ -452,7 +458,7 @@ var SchedulerTableView = A.Component.create({
                 rowNode.append(evtColNode);
             });
 
-            return rowNode;
+            return renderedEvents ? rowNode : null;
         },
 
         /**
@@ -466,10 +472,11 @@ var SchedulerTableView = A.Component.create({
         buildEventsTable: function(rowStartDate, rowEndDate) {
             var instance = this,
                 displayRows = instance.get('displayRows'),
+                end = false,
                 intervalStartDate = DateMath.clearTime(instance._findCurrentIntervalStart()),
                 cacheKey = String(intervalStartDate.getTime()).concat(rowStartDate.getTime()).concat(rowEndDate.getTime()),
                 rowDataTableNode = instance.rowDataTableStack[cacheKey],
-                rowDisplayIndex;
+                rowDisplayIndex = 0;
 
             if (!rowDataTableNode) {
                 rowDataTableNode = A.Node.create(TPL_SVT_TABLE_DATA);
@@ -479,10 +486,20 @@ var SchedulerTableView = A.Component.create({
 
                 tableBody.append(titleRowNode);
 
-                for (rowDisplayIndex = 0; rowDisplayIndex < displayRows; rowDisplayIndex++) {
+                while (!end) {
                     var rowNode = instance.buildEventsRow(rowStartDate, rowEndDate, rowDisplayIndex);
 
-                    tableBody.append(rowNode);
+                    if (rowNode) {
+                        tableBody.append(rowNode);
+
+                        rowDisplayIndex++;
+                        if (displayRows && rowDisplayIndex >= displayRows) {
+                            end = true;
+                        }
+                    }
+                    else {
+                        end = true;
+                    }
                 }
 
                 instance.rowDataTableStack[cacheKey] = rowDataTableNode;
@@ -542,18 +559,9 @@ var SchedulerTableView = A.Component.create({
         buildGridRowNode: function(rowIndex) {
             var instance = this;
 
-            var displayRowsCount = instance._getDisplayRowsCount();
-            var rowRelativeHeight = 100 / displayRowsCount;
             var tableGridNode = instance._getTableGridNode(rowIndex);
 
-            var rowNode = A.Node.create(
-                Lang.sub(
-                    TPL_SVT_ROW, {
-                        height: rowRelativeHeight,
-                        top: rowRelativeHeight * rowIndex
-                    }
-                )
-            );
+            var rowNode = A.Node.create(TPL_SVT_ROW);
 
             rowNode.append(
                 tableGridNode.toggleClass(CSS_SVT_TABLE_GRID_FIRST, (rowIndex === 0))


### PR DESCRIPTION
This fixes scheduler's rendering to allow having month cells without fixed width. It also fixes some checks to make sure that setting the `displayRows` attribute to null or Infinity will work as expected. With these 2 together, scheduler now has the ability to display all events in the month view.

The rendering changes will also enable people who want features like https://issues.liferay.com/browse/AUI-1774 to do it by just extending the CSS, we won't have to do it on Alloy itself.
